### PR TITLE
Updating to .NET Generic Host stops using InMemory Database

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 
 namespace Api
 {
@@ -23,7 +24,7 @@ namespace Api
                 .Build())
                 .Table("AuditEvents"));
 
-            var host = CreateWebHostBuilder(args).Build();
+            var host = CreateHostBuilder(args).Build();
             await host.RunAsync();
 
             Audit.Core.Configuration
@@ -34,7 +35,11 @@ namespace Api
                 });
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
-            => WebHost.CreateDefaultBuilder(args).UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
     }
 }


### PR DESCRIPTION
Following the suggestion of overriding the CreateHost to resolve
any needed services, I got first into an issue of not actually having
called the CreateHost I've overridden. This seems is called only once
the IWebHostBuilder is changed with IHostBuilder in Program.cs
(https://github.com/dotnet-architecture/eShopOnWeb/issues/465)

After this change, the tests aren't using the InMemory database
anymore, but they actually run against the SqlServer, thus
ConfigureServices or ConfigureTestServices is not used as expected.